### PR TITLE
Don't link two targets to one target

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,11 +1,14 @@
 source 'https://github.com/CocoaPods/Specs.git'
-xcodeproj 'catch22.xcodeproj'
-link_with 'catch22', 'catch22Tests'
-
 platform :ios, '8.0'
 
-pod 'MBProgressHUD', '~> 0.8'
-pod 'Locksmith'
-target 'catch22Tests', :exclusive => true do
-    pod 'KIF', '~> 3.0'
+use_frameworks!
+
+target 'catch22' do
+  pod 'MBProgressHUD', '~> 0.8'
+  pod 'Locksmith'
 end
+
+target 'catch22Tests' do
+  pod 'KIF', '~> 3.0'
+end
+

--- a/catch22.xcodeproj/project.pbxproj
+++ b/catch22.xcodeproj/project.pbxproj
@@ -7,8 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		16B2A930F09D262650FD8807 /* libPods-catch22Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5EEAE211D1F1A09697D8F427 /* libPods-catch22Tests.a */; };
-		49121DA59842893A71A83263 /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E0A1578AAA2FA7D5138C8353 /* Pods.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		701C79EE1A7B6034006A44DD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701C79ED1A7B6034006A44DD /* AppDelegate.swift */; };
 		701C79F01A7B6034006A44DD /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701C79EF1A7B6034006A44DD /* ViewController.swift */; };
 		701C79F31A7B6034006A44DD /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 701C79F11A7B6034006A44DD /* Main.storyboard */; };
@@ -16,12 +14,12 @@
 		701C79F81A7B6034006A44DD /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 701C79F61A7B6034006A44DD /* LaunchScreen.xib */; };
 		701C7A041A7B6034006A44DD /* catch22Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701C7A031A7B6034006A44DD /* catch22Tests.swift */; };
 		70328A591A7B661500FF5F28 /* KIFTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70328A581A7B661500FF5F28 /* KIFTest.swift */; };
-		70C9D9511A7B6CD100EDB2F7 /* libPods-catch22Tests-KIF.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 70C9D9501A7B6CD100EDB2F7 /* libPods-catch22Tests-KIF.a */; };
-		95324E60E5A2C4F9D0D7AADC /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E0A1578AAA2FA7D5138C8353 /* Pods.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		936BF8B3FCDF2CB298939E3C /* Pods_catch22.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4F1EF46E94DCC77DB56DEDA /* Pods_catch22.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		E59122107938CC7433FC0E2F /* Pods_catch22Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA7DD020312436B9A4CB5C41 /* Pods_catch22Tests.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		701C79FE1A7B6034006A44DD /* PBXContainerItemProxy */ = {
+		276A2C571A7C0D3B004BCC6F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 701C79E01A7B6034006A44DD /* Project object */;
 			proxyType = 1;
@@ -31,8 +29,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		1477D3152836BB54ED950BF6 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
-		5EEAE211D1F1A09697D8F427 /* libPods-catch22Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-catch22Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		604F5671141EF8C43F1DC7D0 /* Pods-catch22Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-catch22Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-catch22Tests/Pods-catch22Tests.release.xcconfig"; sourceTree = "<group>"; };
 		701C79E81A7B6034006A44DD /* catch22.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = catch22.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		701C79EC1A7B6034006A44DD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		701C79ED1A7B6034006A44DD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -47,8 +44,12 @@
 		70328A5A1A7B667700FF5F28 /* catch22Tests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "catch22Tests-Bridging-Header.h"; sourceTree = "<group>"; };
 		7090FFC51A7B612B00B35F4E /* catch22-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "catch22-Bridging-Header.h"; sourceTree = "<group>"; };
 		70C9D9501A7B6CD100EDB2F7 /* libPods-catch22Tests-KIF.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libPods-catch22Tests-KIF.a"; path = "Pods/build/Debug-iphoneos/libPods-catch22Tests-KIF.a"; sourceTree = "<group>"; };
-		B2AB3E4BE1382F8F9DFD0D49 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
+		B7226D2370C96CE1764E181E /* Pods-catch22Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-catch22Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-catch22Tests/Pods-catch22Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		B808752491751CC8501A6EB6 /* Pods-catch22.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-catch22.release.xcconfig"; path = "Pods/Target Support Files/Pods-catch22/Pods-catch22.release.xcconfig"; sourceTree = "<group>"; };
+		C9659D30C231CB1C2E0F8B94 /* Pods-catch22.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-catch22.debug.xcconfig"; path = "Pods/Target Support Files/Pods-catch22/Pods-catch22.debug.xcconfig"; sourceTree = "<group>"; };
+		DA7DD020312436B9A4CB5C41 /* Pods_catch22Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_catch22Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E0A1578AAA2FA7D5138C8353 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F4F1EF46E94DCC77DB56DEDA /* Pods_catch22.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_catch22.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -56,7 +57,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				95324E60E5A2C4F9D0D7AADC /* Pods.framework in Frameworks */,
+				936BF8B3FCDF2CB298939E3C /* Pods_catch22.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -64,24 +65,13 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				70C9D9511A7B6CD100EDB2F7 /* libPods-catch22Tests-KIF.a in Frameworks */,
-				16B2A930F09D262650FD8807 /* libPods-catch22Tests.a in Frameworks */,
-				49121DA59842893A71A83263 /* Pods.framework in Frameworks */,
+				E59122107938CC7433FC0E2F /* Pods_catch22Tests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		63B947175F0506AE4776F453 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				B2AB3E4BE1382F8F9DFD0D49 /* Pods.debug.xcconfig */,
-				1477D3152836BB54ED950BF6 /* Pods.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
 		701C79DF1A7B6034006A44DD = {
 			isa = PBXGroup;
 			children = (
@@ -89,8 +79,8 @@
 				701C79EA1A7B6034006A44DD /* catch22 */,
 				701C7A001A7B6034006A44DD /* catch22Tests */,
 				701C79E91A7B6034006A44DD /* Products */,
-				63B947175F0506AE4776F453 /* Pods */,
 				BC7399A46C099FB9C8E6E318 /* Frameworks */,
+				D3C3F06A5C425C2788472539 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -147,10 +137,22 @@
 			isa = PBXGroup;
 			children = (
 				70C9D9501A7B6CD100EDB2F7 /* libPods-catch22Tests-KIF.a */,
-				5EEAE211D1F1A09697D8F427 /* libPods-catch22Tests.a */,
 				E0A1578AAA2FA7D5138C8353 /* Pods.framework */,
+				F4F1EF46E94DCC77DB56DEDA /* Pods_catch22.framework */,
+				DA7DD020312436B9A4CB5C41 /* Pods_catch22Tests.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		D3C3F06A5C425C2788472539 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				C9659D30C231CB1C2E0F8B94 /* Pods-catch22.debug.xcconfig */,
+				B808752491751CC8501A6EB6 /* Pods-catch22.release.xcconfig */,
+				B7226D2370C96CE1764E181E /* Pods-catch22Tests.debug.xcconfig */,
+				604F5671141EF8C43F1DC7D0 /* Pods-catch22Tests.release.xcconfig */,
+			);
+			name = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -160,12 +162,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 701C7A071A7B6034006A44DD /* Build configuration list for PBXNativeTarget "catch22" */;
 			buildPhases = (
-				F8C23FD1A0D1D091A9D52CF1 /* Check Pods Manifest.lock */,
 				701C79E41A7B6034006A44DD /* Sources */,
 				701C79E51A7B6034006A44DD /* Frameworks */,
 				701C79E61A7B6034006A44DD /* Resources */,
-				5953F1A226E4CB8FF990C9CF /* Copy Pods Resources */,
-				C08C0C2A83514C33ADF7B6D1 /* Embed Pods Frameworks */,
+				50591F3BD3653175DB6E8864 /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -180,16 +180,17 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 701C7A0A1A7B6034006A44DD /* Build configuration list for PBXNativeTarget "catch22Tests" */;
 			buildPhases = (
-				6E28A7DBCF46DA6D4ACA3361 /* Check Pods Manifest.lock */,
+				000F50F9F0AC510E26865688 /* Check Pods Manifest.lock */,
 				701C79F91A7B6034006A44DD /* Sources */,
 				701C79FA1A7B6034006A44DD /* Frameworks */,
 				701C79FB1A7B6034006A44DD /* Resources */,
-				27C8AEC369524AE4BF848E9A /* Copy Pods Resources */,
+				85EF1033F19CF4E3106E695D /* Embed Pods Frameworks */,
+				0F324C1BBA2A5CBAD57937B0 /* Copy Pods Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				701C79FF1A7B6034006A44DD /* PBXTargetDependency */,
+				276A2C581A7C0D3B004BCC6F /* PBXTargetDependency */,
 			);
 			name = catch22Tests;
 			productName = catch22Tests;
@@ -254,7 +255,22 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		27C8AEC369524AE4BF848E9A /* Copy Pods Resources */ = {
+		000F50F9F0AC510E26865688 /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		0F324C1BBA2A5CBAD57937B0 /* Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -269,37 +285,7 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-catch22Tests/Pods-catch22Tests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		5953F1A226E4CB8FF990C9CF /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		6E28A7DBCF46DA6D4ACA3361 /* Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		C08C0C2A83514C33ADF7B6D1 /* Embed Pods Frameworks */ = {
+		50591F3BD3653175DB6E8864 /* Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -311,22 +297,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-catch22/Pods-catch22-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		F8C23FD1A0D1D091A9D52CF1 /* Check Pods Manifest.lock */ = {
+		85EF1033F19CF4E3106E695D /* Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-catch22Tests/Pods-catch22Tests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -353,10 +339,10 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		701C79FF1A7B6034006A44DD /* PBXTargetDependency */ = {
+		276A2C581A7C0D3B004BCC6F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 701C79E71A7B6034006A44DD /* catch22 */;
-			targetProxy = 701C79FE1A7B6034006A44DD /* PBXContainerItemProxy */;
+			targetProxy = 276A2C571A7C0D3B004BCC6F /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -460,7 +446,7 @@
 		};
 		701C7A081A7B6034006A44DD /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B2AB3E4BE1382F8F9DFD0D49 /* Pods.debug.xcconfig */;
+			baseConfigurationReference = C9659D30C231CB1C2E0F8B94 /* Pods-catch22.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -474,7 +460,7 @@
 		};
 		701C7A091A7B6034006A44DD /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1477D3152836BB54ED950BF6 /* Pods.release.xcconfig */;
+			baseConfigurationReference = B808752491751CC8501A6EB6 /* Pods-catch22.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -487,7 +473,7 @@
 		};
 		701C7A0B1A7B6034006A44DD /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B2AB3E4BE1382F8F9DFD0D49 /* Pods.debug.xcconfig */;
+			baseConfigurationReference = B7226D2370C96CE1764E181E /* Pods-catch22Tests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
@@ -514,7 +500,7 @@
 		};
 		701C7A0C1A7B6034006A44DD /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1477D3152836BB54ED950BF6 /* Pods.release.xcconfig */;
+			baseConfigurationReference = 604F5671141EF8C43F1DC7D0 /* Pods-catch22Tests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;


### PR DESCRIPTION
This project wasn't buildable because the Podfile tried to link against the same target multiple times (catch22Tests). The implicit target for the base Podfile had `link_with 'catch22', 'catch22Tests'` and there was also an explicit target called `catch22Tests` which was also linked. It's not possible to link two targets in a Podfile against a single target in an application (I'll make sure CocoaPods will fail with a friendlier message in the future).

This pull request does two things:
- Remove the broken integration from the project ([pod deintegrate](https://github.com/kylef/cocoapods-deintegrate) + manual tweaking)
- Refactored the Podfile to only link to `catch22Tests` once.
- Reintegrated with `pod install`
